### PR TITLE
Add osticket-multildap-auth to community plugins.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@
 * [Mentioner](https://github.com/clonemeagain/osticket-plugin-mentioner) - Finds Staff mentions in a thread and add's them as collaborators to the ticket.
 * [Prevent Autoscroll](https://github.com/clonemeagain/osticket-plugin-preventautoscroll) - Stops the agent view from scrolling down to the last message in the thread.
 * [Rewriter](https://github.com/clonemeagain/plugin-fwd-rewriter) - An osTicket plugin to rewrite incoming emails.
+* [Multi LDAP Auth](https://github.com/philbertphotos/osticket-multildap-auth) - Plugin for multiple LDAP servers authentication and LDAP Sync.
 
 ### Third Party Integration 
 


### PR DESCRIPTION
Adding a link to the osticket-multildap-auth plugin.